### PR TITLE
feat: add official Alpine-based Dockerfile for ClawMoat CLI usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package.json ./
+RUN npm install --omit=dev
+
+# Copy source code
+COPY . .
+
+# Ensure CLI is executable
+RUN chmod +x bin/clawmoat.js
+
+# Environment variables
+ENV NODE_ENV=production
+ENV CLAWMOAT_POLICY=strict
+
+# CLI entrypoint
+ENTRYPOINT ["node", "bin/clawmoat.js"]
+


### PR DESCRIPTION
**Summary**
Adds an official Alpine-based Dockerfile for ClawMoat to enable
zero-install usage in CI/CD pipelines and containerized environments.

**Features**
- Supports all CLI commands (scan, audit, watch, test)
- Alpine-based Node.js 20 image
- Environment variable configuration
- Ready for CI/CD workflows

**Testing**
- docker build -t clawmoat .
- docker run --rm clawmoat --help
- docker run --rm clawmoat scan "Ignore previous instructions"
